### PR TITLE
Apply querystring to VideoJS.eot it fails to load in IE8

### DIFF
--- a/css/videojs-icons.css
+++ b/css/videojs-icons.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 @font-face {
   font-family: VideoJS;
-  src: url("../fonts/VideoJS.eot) format("eot"); }
+  src: url("../fonts/VideoJS.eot?) format("eot"); }
 
 @font-face {
   font-family: VideoJS;

--- a/css/videojs-icons.css
+++ b/css/videojs-icons.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 @font-face {
   font-family: VideoJS;
-  src: url("../fonts/VideoJS.eot?#iefix") format("eot"); }
+  src: url("../fonts/VideoJS.eot) format("eot"); }
 
 @font-face {
   font-family: VideoJS;

--- a/css/videojs-icons.css
+++ b/css/videojs-icons.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 @font-face {
   font-family: VideoJS;
-  src: url("../fonts/VideoJS.eot?) format("eot"); }
+  src: url("../fonts/VideoJS.eot?") format("eot"); }
 
 @font-face {
   font-family: VideoJS;

--- a/css/videojs-icons.css
+++ b/css/videojs-icons.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 @font-face {
   font-family: VideoJS;
-  src: url("../fonts/VideoJS.eot?") format("eot"); }
+  src: url("../fonts/VideoJS.eot?#iefix") format("eot"); }
 
 @font-face {
   font-family: VideoJS;

--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -3,7 +3,7 @@ $icon-font-path: '../fonts' !default;
 
 @font-face {
   font-family: $icon-font-family;
-  src: url('#{$icon-font-path}/VideoJS.eot?') format('eot');
+  src: url('#{$icon-font-path}/VideoJS.eot?#iefix"') format('eot');
 }
 @font-face {
   font-family: $icon-font-family;


### PR DESCRIPTION
Font VideoJS.eot not loading in ie8 - so the icons are not displayed.
It needs something behind the questionmark, see the solution below
src: url('font/VideoJS.eot?#iefix') format('eot')
