### PR TITLE
Apply querystring to VideoJS.eot in scss it fails to load in IE8

### DIFF
--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -3,7 +3,7 @@ $icon-font-path: '../fonts' !default;
 
 @font-face {
   font-family: $icon-font-family;
-  src: url('#{$icon-font-path}/VideoJS.eot?#iefix') format('eot');
+  src: url('#{$icon-font-path}/VideoJS.eot?') format('eot');
 }
 @font-face {
   font-family: $icon-font-family;

--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -3,7 +3,7 @@ $icon-font-path: '../fonts' !default;
 
 @font-face {
   font-family: $icon-font-family;
-  src: url('#{$icon-font-path}/VideoJS.eot?') format('eot');
+  src: url('#{$icon-font-path}/VideoJS.eot?#iefix') format('eot');
 }
 @font-face {
   font-family: $icon-font-family;

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -3,7 +3,7 @@ $icon-font-path: '../fonts' !default;
 
 @font-face {
   font-family: $icon-font-family;
-  src: url('#{$icon-font-path}/{{fontName}}.eot?') format('eot');
+  src: url('#{$icon-font-path}/{{fontName}}.eot?#iefix') format('eot');
 }
 @font-face {
   font-family: $icon-font-family;


### PR DESCRIPTION
Font VideoJS.eot not loading in ie8 - so the icons are not displayed.
It needs something behind the questionmark, see the solution below
src: url('font/VideoJS.eot?#iefix') format('eot'). 
Moved the correction to _icons.scss file.
