### PR TITLE
fix spdx license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "videojs"
   ],
   "author": "Matthew McClure <m@mmcc.io>",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/videojs/font/issues"
   },


### PR DESCRIPTION
Getting an error when installing this library using npm:

```
npm WARN package.json videojs-font@1.3.0 license should be a valid SPDX license expression
```

Correct one is `Apache-2.0`.
