### PR TITLE
don't quote codepoints for sass and then quote them manually

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -69,10 +69,14 @@ module.exports = function(grunt) {
 
   });
 
+  // Sass turns unicode codepoints into utf8 characters.
+  // We don't want that so we unwrapped them in the templates/scss.hbs file.
+  // After sass has generated our css file, we need to wrap the codepoints
+  // in quotes for it to work.
   grunt.registerTask('wrapcodepoints', function() {
     const cssPath = path.normalize('./css/videojs-icons.css');
     const css = grunt.file.read(cssPath);
-    grunt.file.write(cssPath, css.replace(/(\\f\w+);/g, "'$1'"));
+    grunt.file.write(cssPath, css.replace(/(\\f\w+);/g, "'$1';"));
   });
 
   grunt.registerTask('update-base64', function() {

--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -69,6 +69,12 @@ module.exports = function(grunt) {
 
   });
 
+  grunt.registerTask('wrapcodepoints', function() {
+    const cssPath = path.normalize('./css/videojs-icons.css');
+    const css = grunt.file.read(cssPath);
+    grunt.file.write(cssPath, css.replace(/(\\f\w+);/g, "'$1'"));
+  });
+
   grunt.registerTask('update-base64', function() {
     let iconScssFile = './scss/_icons.scss';
     let fontFiles = {
@@ -90,5 +96,5 @@ module.exports = function(grunt) {
     fs.writeFileSync(iconScssFile, scssContents);
   });
 
-  grunt.registerTask('default', ['generate-font', 'update-base64', 'sass']);
+  grunt.registerTask('default', ['generate-font', 'update-base64', 'sass', 'wrapcodepoints']);
 };

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -16,7 +16,7 @@ $icon-font-path: '../fonts' !default;
 // http://sass-lang.com/documentation/file.SASS_REFERENCE.html#maps
 $icons: (
 	{{#each codepoints}}
-		{{@key}}: '\\{{this}}',
+		{{@key}}: \\{{this}},
 	{{/each}}
 );
 


### PR DESCRIPTION
This is because sass translates the codepoints into utf8 characters and it could cause an issue if your browser is interpreting the css as ascii.
