### PR TITLE
Restore original sass files. Add new sass file.

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
     sass: {
       dist: {
         files: {
-          'css/videojs-icons.css': 'scss/videojs-icons.scss'
+          'css/videojs-icons.css': 'scss/videojs-icons-codepoints.scss'
         }
       }
     },
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
       files: iconFiles,
       dest: 'fonts/',
       fontName: iconConfig['font-name'],
-      cssDest: 'scss/_icons.scss',
+      cssDest: 'scss/_icons-codepoints.scss',
       cssTemplate: './templates/scss.hbs',
       htmlDest: 'preview.html',
       htmlTemplate: './templates/html.hbs',
@@ -77,10 +77,15 @@ module.exports = function(grunt) {
     const cssPath = path.normalize('./css/videojs-icons.css');
     const css = grunt.file.read(cssPath);
     grunt.file.write(cssPath, css.replace(/(\\f\w+);/g, "'$1';"));
+
+    const sassPath = path.normalize('./scss/_icons-codepoints.scss');
+    const normalSassPath = path.normalize('./scss/_icons.scss');
+    const sass = grunt.file.read(sassPath);
+    grunt.file.write(normalSassPath, sass.replace(/(\\f\w+),/g, "'$1',"));
   });
 
   grunt.registerTask('update-base64', function() {
-    let iconScssFile = './scss/_icons.scss';
+    let iconScssFile = './scss/_icons-codepoints.scss';
     let fontFiles = {
       ttf: './fonts/VideoJS.ttf',
       woff: './fonts/VideoJS.woff'

--- a/scss/videojs-icons-codepoints.scss
+++ b/scss/videojs-icons-codepoints.scss
@@ -1,0 +1,1 @@
+@import "icons-codepoints";


### PR DESCRIPTION
The new sass file handles the codepoint fix.
This way, we stay backwards compatible but the generation of our css files can use the codepoint fix and users can opt in.
