### PR TITLE
[IE Emulation] - compatibility for document mode '8'

### DIFF
--- a/css/videojs-icons.css
+++ b/css/videojs-icons.css
@@ -1,5 +1,6 @@
 @font-face {
   font-family: VideoJS;
+  src: url("../fonts/VideoJS.eot");
   src: url("../fonts/VideoJS.eot?#iefix") format("eot"); }
 
 @font-face {

--- a/scss/_icons-codepoints.scss
+++ b/scss/_icons-codepoints.scss
@@ -3,7 +3,8 @@ $icon-font-path: '../fonts' !default;
 
 @font-face {
   font-family: $icon-font-family;
-  src: url('#{$icon-font-path}/VideoJS.eot?#iefix') format('eot');
+	src: url('#{$icon-font-path}/VideoJS.eot');
+	src: url('#{$icon-font-path}/VideoJS.eot?#iefix') format('eot');
 }
 @font-face {
   font-family: $icon-font-family;

--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -3,6 +3,7 @@ $icon-font-path: '../fonts' !default;
 
 @font-face {
   font-family: $icon-font-family;
+  src: url('#{$icon-font-path}/VideoJS.eot');
   src: url('#{$icon-font-path}/VideoJS.eot?#iefix') format('eot');
 }
 @font-face {


### PR DESCRIPTION
This is to solve the issue of videojs font icons not loading in modern IE browsers which are in document mode '8'.  The issue was [originally reported here](https://github.com/videojs/video.js/issues/3238)
