### PR TITLE
don't hardcode font name in grunt task

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -71,9 +71,11 @@ module.exports = function(grunt) {
 
   grunt.registerTask('update-base64', function() {
     let iconScssFile = './scss/_icons.scss';
+    let iconConfig = require('../icons.json');
+    let fontName = iconConfig['font-name'];
     let fontFiles = {
-      ttf: './fonts/VideoJS.ttf',
-      woff: './fonts/VideoJS.woff'
+      ttf: './fonts/' + fontName + '.ttf',
+      woff: './fonts/' + fontName + '.woff'
     };
 
     let scssContents = fs.readFileSync(iconScssFile).toString();


### PR DESCRIPTION
pull it from icons.json instead