### PR TITLE
add skip-next icon as next-item

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -98,5 +98,8 @@
   }, {
     "name": "audio",
     "svg": "hardware/svg/production/ic_headset_48px.svg"
+  }, {
+    "name": "next-item",
+    "svg": "av/svg/production/ic_skip_next_48px.svg"
   }]
 }


### PR DESCRIPTION
This icon is needed for the upcoming playslist-ui feature
Results in:
![screen shot 2017-12-12 at 1 33 47 pm](https://user-images.githubusercontent.com/9756614/33901882-30aa730c-df41-11e7-9cfd-55523561b65a.png)
